### PR TITLE
fix missing libdl dependency for OpenSSL tests

### DIFF
--- a/OpenSSLTests.cmake
+++ b/OpenSSLTests.cmake
@@ -2,7 +2,7 @@ include(CheckCSourceCompiles)
 include(CheckCXXSourceCompiles)
 include(CheckCSourceRuns)
 
-set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES})
+set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES} "-ldl")
 # Use all includes, not just OpenSSL includes to see if there are
 # include files of different versions that do not match
 GET_DIRECTORY_PROPERTY(includes INCLUDE_DIRECTORIES)


### PR DESCRIPTION
Current master branch cmake does not work at mine with the following error:

...
dso_dlfcn.c:(.text+0x11): undefined reference to 'dlopen'
dso_dlfcn.c:(.text+0x24): undefined reference to 'dlsym'
dso_dlfcn.c:(.text+0x2f): undefined reference to 'dlclose'
...

When running check_cxx_source_compiles macro for test OPENSSL_D2I_X509_USES_CHAR, it seems that libdl is missing during link.

Adding libdl as a dependency in CMAKE_REQUIRED_LIBRARIES fixes the problem.